### PR TITLE
Pagination with Search

### DIFF
--- a/src/redux/searchSlice.ts
+++ b/src/redux/searchSlice.ts
@@ -27,9 +27,17 @@ const searchSlice = createSlice({
       }
     },
     addPaginated(state, action: PayloadAction<YoutubeSearchResponse>) {
-      console.log("Did I reach here? Let's see...: ", action.payload);
-      state.searchResults.push(action.payload);
-      console.log("Check store...");
+      // get search results that match query
+      const search = state.searchResults.find(
+        (result) => result.query === action.payload.query
+      );
+
+      if (search) {
+        for (const item of action.payload.items) {
+          search.items.push(item);
+        }
+        search.nextPageToken = action.payload.nextPageToken;
+      }
     },
   },
 });


### PR DESCRIPTION
- Tweaked pagination/store logic so that the correct nextPageToken seems to be working now.
- Upped the maxResults for a video to 50 (the most we can fetch at once), if the amount is too low, it's easy to scroll to the bottom of the page and trigger the pagination before the store has finished updating, which results in duplicate data
  - Another way to fix this might be to move the queries into async thunks in the store, but this works for now