### PR TITLE
Fix subscription links on homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ To contribute to YTT, follow these steps:
 
 5. Replace the variables in `.env` with the keys you just created.
 
-6. Run `npm run dev` and visit the `localhost` link in the output (usually [http://localhost:5173](http://localhost:5173)).
+6. Run `npm install` to install the dependencies and then `npm run dev` to start the site. Visit the `localhost` link in the output (usually [http://localhost:5173](http://localhost:5173)) in your browser to preview the site.

--- a/src/assets/interfaces.ts
+++ b/src/assets/interfaces.ts
@@ -25,7 +25,6 @@ interface AllPlaylistSearchResponse {
 // This represents a single subscription item
 interface Subscription {
   kind: string;
-  etag: string;
   id: string;
   snippet: {
     publishedAt: string;
@@ -70,16 +69,14 @@ interface SinglePlaylistObj {
   items: PlaylistItemObj[];
 }
 
-
-
 // this represents a single playlistItem resource from the /playlistItems endpoint
 interface PlaylistItemObj {
-  id: string,
+  id: string;
   snippet: {
-    publishedAt: string,
-    channelId: string,
-    title: string,
-    description: string,
+    publishedAt: string;
+    channelId: string;
+    title: string;
+    description: string;
     thumbnails: {
       default: {
         url: string;
@@ -96,29 +93,29 @@ interface PlaylistItemObj {
       maxres: {
         url: string;
       };
-    },
-    videoOwnerChannelTitle: string,
-    videoOwnerChannelId: string,
-    position: number,
+    };
+    videoOwnerChannelTitle: string;
+    videoOwnerChannelId: string;
+    position: number;
     resourceId: {
-      kind: string,
-      videoId: string,
-    },
-  },
+      kind: string;
+      videoId: string;
+    };
+  };
   contentDetails: {
     videoId: string;
     videoPublishedAt: string;
-  }
+  };
 }
 
 // this represents a single playlist from /playlists endpoint
 interface PlaylistsObj {
-  id: string,
+  id: string;
   snippet: {
-    publishedAt: string,
-    channelId: string,
-    title: string,
-    description: string,
+    publishedAt: string;
+    channelId: string;
+    title: string;
+    description: string;
     thumbnails: {
       default: {
         url: string;
@@ -135,9 +132,9 @@ interface PlaylistsObj {
       maxres: {
         url: string;
       };
-    },
-    channelTitle: string,
-  },
+    };
+    channelTitle: string;
+  };
 }
 
 interface UserInfo {

--- a/src/pages/Homepage.tsx
+++ b/src/pages/Homepage.tsx
@@ -17,7 +17,7 @@ function Homepage() {
   const user = useAppSelector((state) => state.user.info);
   const playlists = useAppSelector((state) => state.playlists.playlists);
   const totalPlaylistCount = playlists.length;
-  const subscriptionList = useAppSelector((state) => state.subscriptions);
+  const { subscriptionList } = useAppSelector((state) => state.subscriptions);
   const [trendingObj, setTrendingObj] = useState<Video[]>([]);
 
   const maxCharsForTitle = 40;
@@ -213,10 +213,12 @@ function Homepage() {
                 <SideBarUL>
                   <SideBarSpan>Subscriptions</SideBarSpan>
                 </SideBarUL>
-                {subscriptionList.subscriptionList.map((object) => (
+                {subscriptionList.map((object) => (
                   <SidebarLink
-                    href={`https://www.youtube.com/channel/${object.snippet.channelId}`}
+                    href={`https://www.youtube.com/channel/${object.snippet.resourceId.channelId}`}
                     key={object.id}
+                    target="_blank"
+                    rel="noopener noreferrer"
                   >
                     <SidebarLi>{object.snippet.title}</SidebarLi>
                   </SidebarLink>


### PR DESCRIPTION
Subscription links on the homepage were using `snippet.channeld` instead of `snippet.resourceId.channelId`, which led to the links being invalid.